### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### [1.5.1](https://github.com/joolfe/postman-to-openapi/compare/1.5.0...1.5.1) (2020-10-01)
+
+
+### Documentation
+
+* update docs about postman collection version ([7ab3ef5](https://github.com/joolfe/postman-to-openapi/commit/7ab3ef5576f54a409a267c85d731f368f0ea12a9))
+
+
+### Build System
+
+* version to 1.5.1 ([84ff20f](https://github.com/joolfe/postman-to-openapi/commit/84ff20f408b14df279148d7e1a669299c5eee8ad))
+
 ## [1.5.0](https://github.com/joolfe/postman-to-openapi/compare/1.4.1...1.5.0) (2020-10-01)
 
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # [postman-to-openapi](https://joolfe.github.io/postman-to-openapi/)
 
-🛸 Convert Postman Collection v2.1 to OpenAPI v3.0.
+🛸 Convert Postman Collection v2.1/v2.0 to OpenAPI v3.0.
 
-Or in other words, transform [this specification](https://schema.getpostman.com/json/collection/v2.1.0/collection.json) to [this one](http://spec.openapis.org/oas/v3.0.3.html)
+Or in other words, transform [this specification](https://schema.getpostman.com/json/collection/v2.1.0/collection.json) and [also this](https://schema.getpostman.com/json/collection/v2.0.0/collection.json) to [this one](http://spec.openapis.org/oas/v3.0.3.html)
 
 [![build](https://github.com/joolfe/postman-to-openapi/workflows/Build/badge.svg)](https://github.com/joolfe/postman-to-openapi/actions)
 [![codecov](https://codecov.io/gh/joolfe/postman-to-openapi/branch/master/graph/badge.svg)](https://codecov.io/gh/joolfe/postman-to-openapi)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # Postman collection to OpenAPI specs
 
-🛸 Convert Postman Collection v2.1 to OpenAPI v3.0, or in other words, transform [this specification](https://schema.getpostman.com/json/collection/v2.1.0/collection.json) to [this one](http://spec.openapis.org/oas/v3.0.3.html)
+🛸 Convert Postman Collection v2.1 and v2.0 to OpenAPI v3.0, or in other words, transform [this specification](https://schema.getpostman.com/json/collection/v2.1.0/collection.json) and also [this one](https://schema.getpostman.com/json/collection/v2.0.0/collection.json) to [this one](http://spec.openapis.org/oas/v3.0.3.html)
 
 [![build](https://github.com/joolfe/postman-to-openapi/workflows/Build/badge.svg)](https://github.com/joolfe/postman-to-openapi/actions)
 [![codecov](https://codecov.io/gh/joolfe/postman-to-openapi/branch/master/graph/badge.svg)](https://codecov.io/gh/joolfe/postman-to-openapi)
@@ -15,7 +15,7 @@
 
 ## Features at a glance
 
-- Postman Collection v2.1
+- Postman Collection v2.1 and v2.0
 - OpenApi 3.0
 - Basic info API from Postman info or customizable.
 - Basic method conversion (GET, POST, PUT...).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-to-openapi",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-to-openapi",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Convert postman collection to OpenAPI spec",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
### [1.5.1](https://github.com/joolfe/postman-to-openapi/compare/1.5.0...1.5.1) (2020-10-01)


### Documentation

* update docs about postman collection version ([7ab3ef5](https://github.com/joolfe/postman-to-openapi/commit/7ab3ef5576f54a409a267c85d731f368f0ea12a9))
