### PR TITLE
Adding support for POST form data requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,6 +166,25 @@ function parseBody (body = {}, method) {
         'text/plain': {}
       }
       break
+    case "formdata":
+      content = {
+        "multipart/form-data": {
+            schema: {
+              type: "object",
+              properties: body.formdata.reduce((acc, v) => {
+                acc[v.key] = { type: v.type === 'text' ? 'string' : v.type };
+                if (v.hasOwnProperty("description")) {
+                  acc[v.key].description = v.description == '' ? 'Description' : v.description;
+                }
+                if (v.hasOwnProperty("value") && v.value !== '') {
+                  acc[v.key].example = v.value;
+                };
+                return acc;
+              }, {})
+            }
+          }
+        };
+      break;
   }
   return { requestBody: { content } }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -398,10 +398,10 @@ describe('Library specs', function () {
         equal(result, EXPECTED_RESPONSES_NO_HEADERS)
       })
 
-      // it('should parse POST methods with form data', async function () {
-      //   const result = await postmanToOpenApi(COLLECTION_FORM_DATA, OUTPUT_PATH, { pathDepth: 2, responseHeaders: false })
-      //   equal(result, COLLECTION_FORM_DATA)
-      // })
+      it('should parse POST methods with form data', async function () {
+        const result = await postmanToOpenApi(COLLECTION_FORM_DATA, OUTPUT_PATH, {})
+        equal(result, EXPECTED_FORM_DATA)
+      })
     })
   })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -48,6 +48,7 @@ const EXPECTED_RESPONSES = readFileSync('./test/resources/output/Responses.yml',
 const EXPECTED_RESPONSES_MULTI_LANG = readFileSync('./test/resources/output/ResponsesMultiLang.yml', 'utf8')
 const EXPECTED_AUTH_REQUEST = readFileSync('./test/resources/output/AuthRequest.yml', 'utf8')
 const EXPECTED_RESPONSES_NO_HEADERS = readFileSync('./test/resources/output/ResponsesNoHeaders.yml', 'utf8')
+const EXPECTED_FORM_DATA = readFileSync('./test/resources/output/FormData.yml', 'utf8')
 
 const AUTH_DEFINITIONS = {
   myCustomAuth: {
@@ -102,6 +103,7 @@ describe('Library specs', function () {
       const COLLECTION_RESPONSES = `./test/resources/input/${version}/Responses.json`
       const COLLECTION_RESPONSES_MULTI_LANG = `./test/resources/input/${version}/ResponsesMultiLang.json`
       const COLLECTION_AUTH_REQUEST = `./test/resources/input/${version}/AuthRequest.json`
+      const COLLECTION_FORM_DATA = `./test/resources/input/${version}/FormData.json`
 
       it('should work with a basic transform', async function () {
         const result = await postmanToOpenApi(COLLECTION_BASIC, OUTPUT_PATH, {})
@@ -395,6 +397,11 @@ describe('Library specs', function () {
         const result = await postmanToOpenApi(COLLECTION_RESPONSES, OUTPUT_PATH, { pathDepth: 2, responseHeaders: false })
         equal(result, EXPECTED_RESPONSES_NO_HEADERS)
       })
+
+      // it('should parse POST methods with form data', async function () {
+      //   const result = await postmanToOpenApi(COLLECTION_FORM_DATA, OUTPUT_PATH, { pathDepth: 2, responseHeaders: false })
+      //   equal(result, COLLECTION_FORM_DATA)
+      // })
     })
   })
 

--- a/test/resources/input/v2/FormData.json
+++ b/test/resources/input/v2/FormData.json
@@ -1,0 +1,42 @@
+{
+	"info": {
+		"_postman_id": "1eaa74c4-2d76-45f0-bd34-bff5d96f0ba8",
+		"name": "Form Data",
+    "description": "Just a collection with a form data post for test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Register New User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "name",
+							"value": "New User",
+							"description": "full name of the user (accepts spaces)",
+							"type": "text"
+						},
+						{
+							"key": "email",
+							"value": "newuser@example.com",
+							"description": "email of the user (for notifications and login)",
+							"type": "text"
+						},
+						{
+							"key": "password",
+							"value": "pasword123",
+							"description": "password (to be used for logging in)",
+							"type": "text"
+						}
+					]
+				},
+				"url": "https://api.io/register"
+			},
+			"response": []
+		}
+	]
+}

--- a/test/resources/input/v21/FormData.json
+++ b/test/resources/input/v21/FormData.json
@@ -1,0 +1,52 @@
+{
+	"info": {
+		"_postman_id": "1eaa74c4-2d76-45f0-bd34-bff5d96f0ba8",
+		"name": "Form Data",
+    "description": "Just a collection with a form data post for test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Register New User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "name",
+							"value": "New User",
+							"description": "full name of the user (accepts spaces)",
+							"type": "text"
+						},
+						{
+							"key": "email",
+							"value": "newuser@example.com",
+							"description": "email of the user (for notifications and login)",
+							"type": "text"
+						},
+						{
+							"key": "password",
+							"value": "pasword123",
+							"description": "password (to be used for logging in)",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://api.io/register",
+					"protocol": "https",
+					"host": [
+						"api",
+						"io"
+					],
+					"path": [
+						"register"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/resources/output/FormData.yml
+++ b/test/resources/output/FormData.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Form Data
+  description: Just a collection with a form data post for test
+  version: 1.0.0
+servers:
+  - url: https://api.io
+paths:
+  /register:
+    post:
+      tags:
+        - default
+      summary: Register New User
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: full name of the user (accepts spaces)
+                  example: New User
+                email:
+                  type: string
+                  description: email of the user (for notifications and login)
+                  example: newuser@example.com
+                password:
+                  type: string
+                  description: password (to be used for logging in)
+                  example: pasword123
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}


### PR DESCRIPTION
The parseBody function now handles the case where mode = "formdata".
Wrote a test for this new case, but still have some Uncovered Line #s.