### PR TITLE
fix: allow variable replacement in collection without variable key

### DIFF
--- a/lib/var-replacer.js
+++ b/lib/var-replacer.js
@@ -11,10 +11,12 @@ Mustache.Writer.prototype.escapedValue = function escapedValue (token, context, 
 function replacePostmanVariables (collectionString, additionalVars = {}) {
   const postmanJson = JSON.parse(collectionString)
   const { variable } = postmanJson
-  const formatVars = variable.reduce((obj, { key, value }) => {
-    obj[key] = value
-    return obj
-  }, {})
+  const formatVars = variable
+    ? variable.reduce((obj, { key, value }) => {
+      obj[key] = value
+      return obj
+    }, {})
+    : {}
   // Merge collection vars with additional vars
   const context = { ...formatVars, ...additionalVars }
   return Mustache.render(collectionString, context)


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'reduce' of undefined` error.

The user may define the variables at the environment level. In these cases, the variables are not exported in the collection JSON. Added a check to `variable` so that the reduce function is not called on `undefined`.