### PR TITLE
feat: support path parameter & replace the value and description

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,12 +37,13 @@ async function postmanToOpenApi (input, output, {
       request: { url, method, body, description: rawDesc, header, auth },
       name: summary, tag = defaultTag, event: events, response
     } = element
-    const { path, query, protocol, host, port, valid } = scrapeURL(url)
+    const { path, query, protocol, host, port, valid, pathVar } = scrapeURL(url)
     if (valid) {
       domains.add(calculateDomains(protocol, host, port))
       const joinedPath = calculatePath(path, pathDepth)
       if (!paths[joinedPath]) paths[joinedPath] = {}
-      const { description, paramsMeta } = descriptionParse(rawDesc)
+      let { description, paramsMeta } = descriptionParse(rawDesc)
+      paramsMeta = formatPathVarToParamsMeta(paramsMeta, pathVar)
       paths[joinedPath][method.toLowerCase()] = {
         tags: [tag],
         summary,
@@ -333,8 +334,12 @@ function parseOptsAuth (optAuth) {
 function calculatePath (paths, pathDepth) {
   paths = paths.slice(pathDepth) // path depth
   // replace repeated '{' and '}' chars
-  return '/' + paths.map(path => path.replace(/([{}])\1+/g, '$1'))
-    .join('/')
+  // replace `:` chars at first
+  return '/' + paths.map(path => {
+    path = path.replace(/([{}])\1+/g, '$1')
+    path = path.replace(/^:(.*)/g, '{$1}')
+    return path
+  }).join('/')
 }
 
 function calculateDomains (protocol, hosts, port) {
@@ -362,7 +367,8 @@ function scrapeURL (url) {
     protocol: objUrl.protocol.slice(0, -1),
     host: decodeURIComponent(objUrl.hostname).split('.'),
     port: objUrl.port,
-    valid: true
+    valid: true,
+    pathVar: url.variable
   }
 }
 
@@ -527,6 +533,32 @@ function parseResponseHeaders (headerArray, responseHeaders) {
     return acc
   }, {})
   return (Object.keys(headers).length > 0) ? { headers } : {}
+}
+
+/**
+ * This function will parse path variables, format data and merged to paramsMeta
+ * @param {object} paramsMeta
+ * @param {array} variables
+ * @returns {object}
+ */
+function formatPathVarToParamsMeta (paramsMeta = {}, variables = []) {
+  variables.map((variable) => {
+    // if `# postman-to-openapi` is exist, skip replace
+    if (!paramsMeta[variable.key]) {
+      const { key, description, value: example } = variable
+      paramsMeta[key] = {
+        object: 'path',
+        name: key,
+        required: 'true',
+        type: isNaN(variable.value) ? 'string' : 'number',
+        ...(variable.description ? { description } : {}),
+        ...(example ? { example } : {})
+      }
+    }
+
+    return paramsMeta
+  })
+  return paramsMeta
 }
 
 postmanToOpenApi.version = version

--- a/test/resources/input/v2/PathParams.json
+++ b/test/resources/input/v2/PathParams.json
@@ -35,6 +35,75 @@
 				"description": "Obtain a list of users descriptions\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 476587598 |\n| path   | group_id | Group of the user              | true     | string | RETAIL    |"
 			},
 			"response": []
+		},
+		{
+			"name": "Get one users with path params with type",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://api.io/desc/:user_id/:type",
+					"protocol": "https",
+					"host": [
+						"api",
+						"io"
+					],
+					"path": [
+						"desc",
+						":user_id",
+            ":type"
+					],
+					"variable": [
+						{
+							"key": "user_id",
+							"value": "476587598",
+							"description": "This is just a user identifier"
+						},
+            {
+              "key": "type",
+              "value": "user",
+              "description": "This is just a user type"
+            }
+					]
+				},
+				"description": "Obtain a list of users descriptions"
+			},
+			"response": []
+		},
+		{
+			"name": "Get all users with description and params with type",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://api.io/desc/:user_id/:type/all",
+					"protocol": "https",
+					"host": [
+						"api",
+						"io"
+					],
+					"path": [
+						"desc",
+						":user_id",
+						":type",
+						"all"
+					],
+					"variable": [
+						{
+							"key": "user_id",
+							"value": "{{user_id}}",
+							"description": "This description will be replaced"
+						},
+						{
+							"key": "type",
+							"value": "user",
+							"description": "This is just a user type"
+						}
+					]
+				},
+				"description": "Obtain a list of users descriptions\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 476587598 |\n| path   | group_id | Group of the user              | true     | string | RETAIL    |"
+			},
+			"response": []
 		}
 	],
 	"event": [

--- a/test/resources/input/v21/PathParams.json
+++ b/test/resources/input/v21/PathParams.json
@@ -1,60 +1,115 @@
 {
-	"info": {
-		"_postman_id": "da50fa53-6326-4c7c-bfd8-6041a2c625d9",
-		"name": "Path Params",
-		"description": "Collection to test path parameters",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"item": [
+  "info": {
+    "_postman_id": "da50fa53-6326-4c7c-bfd8-6041a2c625d9",
+    "name": "Path Params",
+    "description": "Collection to test path parameters",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get one users info",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.io/users/{{user_id}}",
+          "protocol": "https",
+          "host": [
+            "api",
+            "io"
+          ],
+          "path": [
+            "users",
+            "{{user_id}}"
+          ]
+        },
+        "description": "Obtain a list of users that fullfill the conditions of the filters"
+      },
+      "response": []
+    },
+    {
+      "name": "Get one customer",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.io/customer/{{customer-id}}",
+          "protocol": "https",
+          "host": [
+            "api",
+            "io"
+          ],
+          "path": [
+            "customer",
+            "{{customer-id}}"
+          ]
+        },
+        "description": "Obtain one customer info"
+      },
+      "response": []
+    },
+    {
+      "name": "Get one users with description",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.io/desc/{{user_id}}",
+          "protocol": "https",
+          "host": [
+            "api",
+            "io"
+          ],
+          "path": [
+            "desc",
+            "{{user_id}}"
+          ]
+        },
+        "description": "Obtain a list of users descriptions\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 476587598 |\n| path   | group_id | Group of the user              | true     | string | RETAIL    |"
+      },
+      "response": []
+    },
+    {
+      "name": "Get one users with path params with type",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.io/desc/:user_id/:type",
+          "protocol": "https",
+          "host": [
+            "api",
+            "io"
+          ],
+          "path": [
+            "desc",
+            ":user_id",
+            ":type"
+          ],
+          "variable": [
+            {
+              "key": "user_id",
+              "value": "476587598",
+              "description": "This is just a user identifier"
+            },
+            {
+              "key": "type",
+              "value": "user",
+              "description": "This is just a user type"
+            }
+          ]
+        },
+        "description": "Obtain a list of users descriptions"
+      },
+      "response": []
+    },
 		{
-			"name": "Get one users info",
+			"name": "Get all users with description and params with type",
 			"request": {
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "https://api.io/users/{{user_id}}",
-					"protocol": "https",
-					"host": [
-						"api",
-						"io"
-					],
-					"path": [
-						"users",
-						"{{user_id}}"
-					]
-				},
-				"description": "Obtain a list of users that fullfill the conditions of the filters"
-			},
-			"response": []
-		},
-		{
-			"name": "Get one customer",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "https://api.io/customer/{{customer-id}}",
-					"protocol": "https",
-					"host": [
-						"api",
-						"io"
-					],
-					"path": [
-						"customer",
-						"{{customer-id}}"
-					]
-				},
-				"description": "Obtain one customer info"
-			},
-			"response": []
-		},
-		{
-			"name": "Get one users with description",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "https://api.io/desc/{{user_id}}",
+					"raw": "https://api.io/desc/:user_id/:type/all",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -62,35 +117,49 @@
 					],
 					"path": [
 						"desc",
-						"{{user_id}}"
+						":user_id",
+						":type",
+						"all"
+					],
+					"variable": [
+						{
+							"key": "user_id",
+							"value": "{{user_id}}",
+							"description": "This description will be replaced"
+						},
+						{
+							"key": "type",
+							"value": "user",
+							"description": "This is just a user type"
+						}
 					]
 				},
 				"description": "Obtain a list of users descriptions\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 476587598 |\n| path   | group_id | Group of the user              | true     | string | RETAIL    |"
 			},
 			"response": []
 		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"id": "8d6ddd6c-f1a8-4a68-91e0-07ab38f881a8",
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"id": "e9cb3ab3-f140-42b3-8c12-17667c92c907",
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"protocolProfileBehavior": {}
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "id": "8d6ddd6c-f1a8-4a68-91e0-07ab38f881a8",
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "id": "e9cb3ab3-f140-42b3-8c12-17667c92c907",
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "protocolProfileBehavior": {}
 }

--- a/test/resources/output/PathParams.yml
+++ b/test/resources/output/PathParams.yml
@@ -59,3 +59,55 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /desc/{user_id}/{type}:
+    get:
+      tags:
+        - default
+      summary: Get one users with path params with type
+      description: Obtain a list of users descriptions
+      parameters:
+        - name: user_id
+          in: path
+          schema:
+            type: number
+          required: true
+          description: This is just a user identifier
+          example: '476587598'
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+          description: This is just a user type
+          example: user
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /desc/{user_id}/{type}/all:
+    get:
+      tags:
+        - default
+      summary: Get all users with description and params with type
+      description: Obtain a list of users descriptions
+      parameters:
+        - name: user_id
+          in: path
+          schema:
+            type: number
+          required: true
+          description: This is just a user identifier
+          example: '476587598'
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+          description: This is just a user type
+          example: user
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}


### PR DESCRIPTION
Hi @joolfe ,
  About #130 I implement this feature and compatible with `# postman-to-openapi` description.
  If use `# postman-to-openapi`, the description have higher priority...

Thanks
Best regards 