### PR TITLE
fix: convert collections with `collection` wrapper attribute

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ async function postmanToOpenApi (input, output, {
   if (replaceVars) {
     collectionFile = replacePostmanVariables(collectionFile, additionalVars)
   }
-  const postmanJson = JSON.parse(collectionFile)
+  const _postmanJson = JSON.parse(collectionFile)
+  const postmanJson = _postmanJson.collection || _postmanJson
   const { item: items, variable = [] } = postmanJson
   const paths = {}
   const domains = new Set()

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -56,6 +56,7 @@ const EXPECTED_VARIABLES_ADDITIONAL = readFileSync('./test/resources/output/Vari
 const EXPECTED_BASEPATH_VAR = readFileSync('./test/resources/output/BasepathVar.yml', 'utf8')
 const EXPECTED_RAW_BODY = readFileSync('./test/resources/output/RawBody.yml', 'utf8')
 const EXPECTED_NULL_HEADER = readFileSync('./test/resources/output/NullHeader.yml', 'utf8')
+const EXPECTED_COLLECTION_WRAPPER = readFileSync('./test/resources/output/CollectionWrapper.yml', 'utf8')
 
 const AUTH_DEFINITIONS = {
   myCustomAuth: {
@@ -115,6 +116,7 @@ describe('Library specs', function () {
       const COLLECTION_VARIABLES = `./test/resources/input/${version}/Variables.json`
       const COLLECTION_BASEURL_VAR = `./test/resources/input/${version}/BasepathVar.json`
       const COLLECTION_RAW_BODY = `./test/resources/input/${version}/RawBody.json`
+      const COLLECTION_COLLECTION_WRAPPER = `./test/resources/input/${version}/CollectionWrapper.json`
 
       it('should work with a basic transform', async function () {
         const result = await postmanToOpenApi(COLLECTION_BASIC, OUTPUT_PATH, {})
@@ -459,6 +461,11 @@ describe('Library specs', function () {
       it('should try to parse raw body as json but fallback to text', async function () {
         const result = await postmanToOpenApi(COLLECTION_RAW_BODY, OUTPUT_PATH, {})
         equal(result, EXPECTED_RAW_BODY)
+      })
+
+      it('should work with collection wrapper attribute', async function () {
+        const result = await postmanToOpenApi(COLLECTION_COLLECTION_WRAPPER, OUTPUT_PATH, {})
+        equal(result, EXPECTED_COLLECTION_WRAPPER)
       })
     })
   })

--- a/test/resources/input/v2/CollectionWrapper.json
+++ b/test/resources/input/v2/CollectionWrapper.json
@@ -1,0 +1,103 @@
+{
+  "collection": {
+    "info": {
+      "_postman_id": "0f93eca8-921e-4b0d-9ac0-15f96a56eae8",
+      "name": "AuthBasic",
+      "description": "Collection to test authorization global",
+      "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+    },
+    "item": [
+      {
+        "name": "Create new User Copy",
+        "request": {
+          "method": "POST",
+          "header": [],
+          "body": {
+            "mode": "raw",
+            "raw": "{\n    \"example\": \"field\",\n    \"other\": {\n        \"data1\": \"yes\",\n        \"data2\": \"no\"\n    }\n}",
+            "options": {
+              "raw": {
+                "language": "json"
+              }
+            }
+          },
+          "url": "https://api.io/users",
+          "description": "Create a new user into your amazing API"
+        },
+        "response": []
+      },
+      {
+        "name": "Get list of users",
+        "request": {
+          "method": "GET",
+          "header": [],
+          "url": {
+            "raw": "https://api.io/users?age=45&name=Jhon&review=true&number=23.56",
+            "protocol": "https",
+            "host": [
+              "api",
+              "io"
+            ],
+            "path": [
+              "users"
+            ],
+            "query": [
+              {
+                "key": "age",
+                "value": "45",
+                "description": "Filter by age"
+              },
+              {
+                "key": "name",
+                "value": "Jhon",
+                "description": "Filter by name"
+              },
+              {
+                "key": "review",
+                "value": "true",
+                "description": "Indicate if should be reviewed or not"
+              },
+              {
+                "key": "number",
+                "value": "23.56",
+                "description": "This is a number"
+              }
+            ]
+          },
+          "description": "Obtain a list of users that fullfill the conditions of the filters"
+        },
+        "response": []
+      }
+    ],
+    "auth": {
+      "type": "basic",
+      "basic": {
+        "password": "ssss",
+        "username": "sss"
+      }
+    },
+    "event": [
+      {
+        "listen": "prerequest",
+        "script": {
+          "id": "7b3e1a28-e253-4cd9-ac26-2d9d52092d80",
+          "type": "text/javascript",
+          "exec": [
+            ""
+          ]
+        }
+      },
+      {
+        "listen": "test",
+        "script": {
+          "id": "b50e4ce3-8104-4eb7-bc20-50e6f3f5edab",
+          "type": "text/javascript",
+          "exec": [
+            ""
+          ]
+        }
+      }
+    ],
+    "protocolProfileBehavior": {}
+  }
+}

--- a/test/resources/input/v21/CollectionWrapper.json
+++ b/test/resources/input/v21/CollectionWrapper.json
@@ -1,0 +1,121 @@
+{
+  "collection": {
+    "info": {
+      "_postman_id": "2c1cccde-7a4d-4dea-bcd8-ce39544b0432",
+      "name": "AuthBasic",
+      "description": "Collection to test authorization global",
+      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    },
+    "item": [
+      {
+        "name": "Create new User Copy",
+        "request": {
+          "method": "POST",
+          "header": [],
+          "body": {
+            "mode": "raw",
+            "raw": "{\n    \"example\": \"field\",\n    \"other\": {\n        \"data1\": \"yes\",\n        \"data2\": \"no\"\n    }\n}",
+            "options": {
+              "raw": {
+                "language": "json"
+              }
+            }
+          },
+          "url": {
+            "raw": "https://api.io/users",
+            "protocol": "https",
+            "host": [
+              "api",
+              "io"
+            ],
+            "path": [
+              "users"
+            ]
+          },
+          "description": "Create a new user into your amazing API"
+        },
+        "response": []
+      },
+      {
+        "name": "Get list of users",
+        "request": {
+          "method": "GET",
+          "header": [],
+          "url": {
+            "raw": "https://api.io/users?age=45&name=Jhon&review=true&number=23.56",
+            "protocol": "https",
+            "host": [
+              "api",
+              "io"
+            ],
+            "path": [
+              "users"
+            ],
+            "query": [
+              {
+                "key": "age",
+                "value": "45",
+                "description": "Filter by age"
+              },
+              {
+                "key": "name",
+                "value": "Jhon",
+                "description": "Filter by name"
+              },
+              {
+                "key": "review",
+                "value": "true",
+                "description": "Indicate if should be reviewed or not"
+              },
+              {
+                "key": "number",
+                "value": "23.56",
+                "description": "This is a number"
+              }
+            ]
+          },
+          "description": "Obtain a list of users that fullfill the conditions of the filters"
+        },
+        "response": []
+      }
+    ],
+    "auth": {
+      "type": "basic",
+      "basic": [
+        {
+          "key": "password",
+          "value": "ssss",
+          "type": "string"
+        },
+        {
+          "key": "username",
+          "value": "sss",
+          "type": "string"
+        }
+      ]
+    },
+    "event": [
+      {
+        "listen": "prerequest",
+        "script": {
+          "id": "631b8a30-dcaf-449a-9f2e-83a9f13044ae",
+          "type": "text/javascript",
+          "exec": [
+            ""
+          ]
+        }
+      },
+      {
+        "listen": "test",
+        "script": {
+          "id": "b43e5a36-2b9e-47a0-aab9-edc036b968a6",
+          "type": "text/javascript",
+          "exec": [
+            ""
+          ]
+        }
+      }
+    ],
+    "protocolProfileBehavior": {}
+  }
+}

--- a/test/resources/output/CollectionWrapper.yml
+++ b/test/resources/output/CollectionWrapper.yml
@@ -1,0 +1,71 @@
+openapi: 3.0.0
+info:
+  title: AuthBasic
+  description: Collection to test authorization global
+  version: 1.0.0
+servers:
+  - url: https://api.io
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+security:
+  - basicAuth: []
+paths:
+  /users:
+    post:
+      tags:
+        - default
+      summary: Create new User Copy
+      description: Create a new user into your amazing API
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                example: field
+                other:
+                  data1: 'yes'
+                  data2: 'no'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - default
+      summary: Get list of users
+      description: Obtain a list of users that fullfill the conditions of the filters
+      parameters:
+        - name: age
+          in: query
+          schema:
+            type: integer
+          description: Filter by age
+          example: '45'
+        - name: name
+          in: query
+          schema:
+            type: string
+          description: Filter by name
+          example: Jhon
+        - name: review
+          in: query
+          schema:
+            type: boolean
+          description: Indicate if should be reviewed or not
+          example: 'true'
+        - name: number
+          in: query
+          schema:
+            type: number
+          description: This is a number
+          example: '23.56'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}


### PR DESCRIPTION
Allow converting collections with the `collection` wrapper
attribute (e.g. collections retrieved with `curl` using
the Postman API). See #120, #161.