### PR TITLE
feat: allow javascript object as input and output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { promises: { writeFile, readFile } } = require('fs')
+const fs = require('fs');
 const { dump } = require('js-yaml')
 const { parseMdTable } = require('./md-utils')
 const { version } = require('../package.json')
@@ -12,11 +12,11 @@ async function postmanToOpenApi (input, output, {
   responseHeaders = true, replaceVars = false, additionalVars = {}
 } = {}) {
   // TODO validate?
-  let collectionFile = await resolveInput(input)
+  let collectionFile = typeof input === "string" ? await resolveInput(input) : input;
   if (replaceVars) {
     collectionFile = replacePostmanVariables(collectionFile, additionalVars)
   }
-  const _postmanJson = JSON.parse(collectionFile)
+  const _postmanJson = typeof collectionFile === "string" ? JSON.parse(collectionFile) : collectionFile;
   const postmanJson = _postmanJson.collection || _postmanJson
   const { item: items, variable = [] } = postmanJson
   const paths = {}
@@ -65,9 +65,12 @@ async function postmanToOpenApi (input, output, {
     ...parseTags(tags),
     paths
   }
+  if (output === 'raw') {
+    return openApi;
+  }
   const openApiYml = dump(openApi, { skipInvalid: true })
   if (output != null) {
-    await writeFile(output, openApiYml, 'utf8')
+    await fs.writeFileSync(output, openApiYml, 'utf8')
   }
   return openApiYml
 }
@@ -562,7 +565,7 @@ async function resolveInput (input) {
   if (input.trim().startsWith('{')) {
     return input
   } else {
-    return readFile(input, 'utf8')
+    return fs.readFileSync(input, 'utf8')
   }
 }
 


### PR DESCRIPTION
I wanted this to integrate this awesome tool into my browser based react application.

Everything I wanted is usable in a browser except `fs`, which I don't really need in my case.

Hence this fixes the hard requirement of `fs`. Only depend on `fs` if someone is interested in reading or writing files