### PR TITLE
Fixing issue when response example body is null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -540,7 +540,7 @@ function parseExamples (bodies, language) {
 
 function safeSampleParse (body, name, language) {
   try {
-    return (language === 'json') ? JSON.parse((body.trim().length === 0) ? '{}' : body) : body
+    return (language === 'json') ? JSON.parse((body.length === 0 || body.trim().length === 0) ? '{}' : body) : body
   } catch (error) {
     throw new Error('Error parsing response example "' + name + '" parse error is: ' + error.message)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -540,7 +540,7 @@ function parseExamples (bodies, language) {
 
 function safeSampleParse (body, name, language) {
   try {
-    return (language === 'json') ? JSON.parse((body.length === 0 || body.trim().length === 0) ? '{}' : body) : body
+    return (language === 'json') ? JSON.parse((!body || body.trim().length === 0) ? '{}' : body) : body
   } catch (error) {
     throw new Error('Error parsing response example "' + name + '" parse error is: ' + error.message)
   }


### PR DESCRIPTION
When body of a response example is null in the postman collection, conversion fails with  "parse error is: Cannot read property 'trim' of null"