### PR TITLE
fix versions being infered as numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,7 +269,7 @@ function getVarValue (variables, name, def = undefined) {
 /* calculate the type of a variable based on OPenApi types */
 function inferType (value) {
   if (/^\d+$/.test(value)) return 'integer'
-  if (/-?\d+\.\d+/.test(value)) return 'number'
+  if (/^-?\d+(\.\d+)?$/.test(value)) return 'number'
   if (/^(true|false)$/.test(value)) return 'boolean'
   return 'string'
 }


### PR DESCRIPTION
Fixes an issue where versions are inferred as numbers. 
Example 1.41.1.1 is classified as a number, when it is a string.
Added a check to make sure there is no more than one ".n" in a number