### PR TITLE
Allow parsing request bodies and examples that has JSON with comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const { dump } = require('js-yaml')
 const { parseMdTable } = require('./md-utils')
 const { version } = require('../package.json')
 const replacePostmanVariables = require('./var-replacer')
+const jsonc = require('jsonc-parser')
 
 async function postmanToOpenApi (input, output, {
   info = {}, defaultTag = 'default', pathDepth = 0,
@@ -149,9 +150,9 @@ function parseBody (body = {}, method) {
       let example = ''
       if (language === 'json') {
         if (raw) {
-          try {
-            example = JSON.parse(raw)
-          } catch (e) {
+          const errors = []
+          example = jsonc.parse(raw, errors)
+          if (errors.length > 0) {
             example = raw
           }
         }
@@ -539,11 +540,15 @@ function parseExamples (bodies, language) {
 }
 
 function safeSampleParse (body, name, language) {
-  try {
-    return (language === 'json') ? JSON.parse((body.trim().length === 0) ? '{}' : body) : body
-  } catch (error) {
-    throw new Error('Error parsing response example "' + name + '" parse error is: ' + error.message)
+  if (language === 'json') {
+    const errors = []
+    const parsedBody = jsonc.parse((body.trim().length === 0) ? '{}' : body, errors)
+    if (errors.length > 0) {
+      throw new Error('Error parsing response example "' + name + '"')
+    }
+    return parsedBody
   }
+  return body
 }
 
 function parseResponseHeaders (headerArray, responseHeaders) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "commander": "^8.3.0",
         "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.0.0",
         "marked": "^4.0.16",
         "mustache": "^4.2.0"
       },
@@ -3376,6 +3377,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -7829,6 +7835,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "dependencies": {
     "commander": "^8.3.0",
     "js-yaml": "^4.1.0",
+    "jsonc-parser": "3.0.0",
     "marked": "^4.0.16",
     "mustache": "^4.2.0"
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,6 +59,7 @@ const EXPECTED_BASEPATH_VAR = readFileSync('./test/resources/output/BasepathVar.
 const EXPECTED_RAW_BODY = readFileSync('./test/resources/output/RawBody.yml', 'utf8')
 const EXPECTED_NULL_HEADER = readFileSync('./test/resources/output/NullHeader.yml', 'utf8')
 const EXPECTED_COLLECTION_WRAPPER = readFileSync('./test/resources/output/CollectionWrapper.yml', 'utf8')
+const EXPECTED_COLLECTION_JSON_COMMENTS = readFileSync('./test/resources/output/JsonComments.yml', 'utf8')
 
 const AUTH_DEFINITIONS = {
   myCustomAuth: {
@@ -121,6 +122,7 @@ describe('Library specs', function () {
       const COLLECTION_COLLECTION_WRAPPER = `./test/resources/input/${version}/CollectionWrapper.json`
       const COLLECTION_RESPONSES_JSON_ERROR = `./test/resources/input/${version}/ResponsesJsonError.json`
       const COLLECTION_RESPONSES_EMPTY = `./test/resources/input/${version}/ResponsesEmpty.json`
+      const COLLECTION_JSON_COMMENTS = `./test/resources/input/${version}/JsonComments.json`
 
       it('should work with a basic transform', async function () {
         const result = await postmanToOpenApi(COLLECTION_BASIC, OUTPUT_PATH, {})
@@ -475,13 +477,18 @@ describe('Library specs', function () {
       it('should return friendly error message when a response sample body has an error in JSON', async function () {
         await rejects(postmanToOpenApi(COLLECTION_RESPONSES_JSON_ERROR, OUTPUT_PATH, {}), {
           name: 'Error',
-          message: "Error parsing response example \"Create new User automatic id\" parse error is: Unexpected token ' in JSON at position 1"
+          message: 'Error parsing response example "Create new User automatic id"'
         })
       })
 
       it('should not fail if response body is json but empty', async function () {
         const result = await postmanToOpenApi(COLLECTION_RESPONSES_EMPTY, OUTPUT_PATH, { pathDepth: 2 })
         equal(result, EXPECTED_EMPTY_RESPONSES)
+      })
+
+      it('should not fail if request body and response body have json with comments', async function () {
+        const result = await postmanToOpenApi(COLLECTION_JSON_COMMENTS, OUTPUT_PATH, { pathDepth: 2 })
+        equal(result, EXPECTED_COLLECTION_JSON_COMMENTS)
       })
     })
   })

--- a/test/resources/input/v2/JsonComments.json
+++ b/test/resources/input/v2/JsonComments.json
@@ -1,0 +1,341 @@
+{
+	"info": {
+		"_postman_id": "13b914f5-fe37-4c4f-9733-d6ec7c90e2c5",
+		"name": "JsonComments",
+		"description": "Postman collection with saved responses",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
+		"_exporter_id": "16610684"
+	},
+	"item": [
+		{
+			"name": "Create new User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"100\",                                                            // userId\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n  }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+				"description": "Create a new user into your amazing API"
+			},
+			"response": [
+				{
+					"name": "Create new User example",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"100\",                                                            // userId\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n  }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users"
+					},
+					"status": "Created",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:42:32 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"100\",                                                 // id was supplied in the request\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				},
+				{
+					"name": "Create new User automatic id",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users"
+					},
+					"status": "Created",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:49:09 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"54\",                                             // id got created automatically\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Get User data",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "file",
+					"file": {}
+				},
+				"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/{{user_id}}",
+				"description": "Retrieve the user data\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 54 |"
+			},
+			"response": [
+				{
+					"name": "Get User data NOT FOUND",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/100"
+					},
+					"status": "Not Found",
+					"code": 404,
+					"_postman_previewlanguage": "text",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "11"
+						},
+						{
+							"key": "Etag",
+							"value": "\"1592724850\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:48:30 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "\"Not found\""
+				},
+				{
+					"name": "Get User data OK",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/{{user_id}}"
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "127"
+						},
+						{
+							"key": "Etag",
+							"value": "\"1711725458\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:48:00 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"50\",                                             // id is returned in response\n    \"createdAt\": \"2021-06-04T23:41:02.287Z\",\n    \"name\": \"Leanne\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/bartjo_128.jpg\"\n}"
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "version",
+			"value": "1.2.0"
+		},
+		{
+			"key": "user_id",
+			"value": "50"
+		}
+	]
+}

--- a/test/resources/input/v21/JsonComments.json
+++ b/test/resources/input/v21/JsonComments.json
@@ -1,0 +1,422 @@
+{
+	"info": {
+		"_postman_id": "13b914f5-fe37-4c4f-9733-d6ec7c90e2c5",
+		"name": "JsonComments",
+		"description": "Postman collection with saved responses",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "16610684"
+	},
+	"item": [
+		{
+			"name": "Create new User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"100\",                                                            // userId\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n  }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+					"protocol": "https",
+					"host": [
+						"60bb37ab42e1d000176206c3",
+						"mockapi",
+						"io"
+					],
+					"path": [
+						"api",
+						"v1",
+						"users"
+					]
+				},
+				"description": "Create a new user into your amazing API"
+			},
+			"response": [
+				{
+					"name": "Create new User example",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"100\",                                                            // userId\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n  }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+							"protocol": "https",
+							"host": [
+								"60bb37ab42e1d000176206c3",
+								"mockapi",
+								"io"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"status": "Created",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:42:32 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"100\",                                                 // id was supplied in the request\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				},
+				{
+					"name": "Create new User automatic id",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",                                // timestamp of creation\n    \"name\": \"Carol\",                                                        // name of user\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"      // user's avatar\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+							"protocol": "https",
+							"host": [
+								"60bb37ab42e1d000176206c3",
+								"mockapi",
+								"io"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"status": "Created",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:49:09 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"54\",                                             // id got created automatically\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Get User data",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "file",
+					"file": {}
+				},
+				"url": {
+					"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/{{user_id}}",
+					"protocol": "https",
+					"host": [
+						"60bb37ab42e1d000176206c3",
+						"mockapi",
+						"io"
+					],
+					"path": [
+						"api",
+						"v1",
+						"users",
+						"{{user_id}}"
+					]
+				},
+				"description": "Retrieve the user data\n\n# postman-to-openapi\n\n| object | name     | description                    | required | type   | example   |\n|--------|----------|--------------------------------|----------|--------|-----------|\n| path   | user_id  | This is just a user identifier | true     | number | 54 |"
+			},
+			"response": [
+				{
+					"name": "Get User data NOT FOUND",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/100",
+							"protocol": "https",
+							"host": [
+								"60bb37ab42e1d000176206c3",
+								"mockapi",
+								"io"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"100"
+							]
+						}
+					},
+					"status": "Not Found",
+					"code": 404,
+					"_postman_previewlanguage": "text",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "11"
+						},
+						{
+							"key": "Etag",
+							"value": "\"1592724850\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:48:30 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "\"Not found\""
+				},
+				{
+					"name": "Get User data OK",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users/{{user_id}}",
+							"protocol": "https",
+							"host": [
+								"60bb37ab42e1d000176206c3",
+								"mockapi",
+								"io"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"{{user_id}}"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "127"
+						},
+						{
+							"key": "Etag",
+							"value": "\"1711725458\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:48:00 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"50\",                                             // id is returned in response\n    \"createdAt\": \"2021-06-04T23:41:02.287Z\",\n    \"name\": \"Leanne\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/bartjo_128.jpg\"\n}"
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "version",
+			"value": "1.2.0"
+		},
+		{
+			"key": "user_id",
+			"value": "50"
+		}
+	]
+}

--- a/test/resources/output/JsonComments.yml
+++ b/test/resources/output/JsonComments.yml
@@ -1,0 +1,222 @@
+openapi: 3.0.0
+info:
+  title: JsonComments
+  description: Postman collection with saved responses
+  version: 1.2.0
+servers:
+  - url: https://60bb37ab42e1d000176206c3.mockapi.io
+paths:
+  /users:
+    post:
+      tags:
+        - default
+      summary: Create new User
+      description: Create a new user into your amazing API
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                id: '100'
+                createdAt: '2021-06-04T15:50:38.568Z'
+                name: Carol
+                avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg
+      responses:
+        '201':
+          description: Created
+          headers:
+            Server:
+              schema:
+                type: string
+                example: Cowboy
+            Connection:
+              schema:
+                type: string
+                example: keep-alive
+            X-Powered-By:
+              schema:
+                type: string
+                example: Express
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                example: '*'
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+                example: GET,PUT,POST,DELETE,OPTIONS
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+                example: X-Requested-With,Content-Type,Cache-Control,access_token
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Content-Length:
+              schema:
+                type: integer
+                example: '131'
+            Vary:
+              schema:
+                type: string
+                example: Accept-Encoding
+            Date:
+              schema:
+                type: string
+                example: Sat, 05 Jun 2021 08:42:32 GMT
+            Via:
+              schema:
+                type: number
+                example: 1.1 vegur
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                example-0:
+                  summary: Create new User example
+                  value:
+                    id: '100'
+                    createdAt: '2021-06-04T15:50:38.568Z'
+                    name: Carol
+                    avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg
+                example-1:
+                  summary: Create new User automatic id
+                  value:
+                    id: '54'
+                    createdAt: '2021-06-04T15:50:38.568Z'
+                    name: Carol
+                    avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg
+  /users/{user_id}:
+    get:
+      tags:
+        - default
+      summary: Get User data
+      description: Retrieve the user data
+      parameters:
+        - name: user_id
+          in: path
+          schema:
+            type: number
+          required: true
+          description: This is just a user identifier
+          example: '54'
+      responses:
+        '200':
+          description: OK
+          headers:
+            Server:
+              schema:
+                type: string
+                example: Cowboy
+            Connection:
+              schema:
+                type: string
+                example: keep-alive
+            X-Powered-By:
+              schema:
+                type: string
+                example: Express
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                example: '*'
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+                example: GET,PUT,POST,DELETE,OPTIONS
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+                example: X-Requested-With,Content-Type,Cache-Control,access_token
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Content-Length:
+              schema:
+                type: integer
+                example: '127'
+            Etag:
+              schema:
+                type: string
+                example: '"1711725458"'
+            Vary:
+              schema:
+                type: string
+                example: Accept-Encoding
+            Date:
+              schema:
+                type: string
+                example: Sat, 05 Jun 2021 08:48:00 GMT
+            Via:
+              schema:
+                type: number
+                example: 1.1 vegur
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                id: '50'
+                createdAt: '2021-06-04T23:41:02.287Z'
+                name: Leanne
+                avatar: https://cdn.fakercloud.com/avatars/bartjo_128.jpg
+        '404':
+          description: Not Found
+          headers:
+            Server:
+              schema:
+                type: string
+                example: Cowboy
+            Connection:
+              schema:
+                type: string
+                example: keep-alive
+            X-Powered-By:
+              schema:
+                type: string
+                example: Express
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                example: '*'
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+                example: GET,PUT,POST,DELETE,OPTIONS
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+                example: X-Requested-With,Content-Type,Cache-Control,access_token
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Content-Length:
+              schema:
+                type: integer
+                example: '11'
+            Etag:
+              schema:
+                type: string
+                example: '"1592724850"'
+            Vary:
+              schema:
+                type: string
+                example: Accept-Encoding
+            Date:
+              schema:
+                type: string
+                example: Sat, 05 Jun 2021 08:48:30 GMT
+            Via:
+              schema:
+                type: number
+                example: 1.1 vegur
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: '"Not found"'


### PR DESCRIPTION
Postman supports JSON with comments for request bodies and examples. See issue filed at: https://github.com/joolfe/postman-to-openapi/issues/188.

This PR updates the library used to parse JSON from native `JSON.parse` to one supported by Microsoft: https://github.com/microsoft/node-jsonc-parser.

This library is used by VSCode and thus has a high chance of being maintained. It is fully backwards compatible with the native JSON library,