### PR TITLE
Fixed crash because attempting to query undefined object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -366,7 +366,7 @@ function calculateDomains (protocol, hosts, port) {
  */
 function scrapeURL (url) {
   // Avoid parse empty url request
-  if (url === '' || url.raw === '') {
+  if (url ===undefined || url === '' || url.raw === '') {
     return { valid: false }
   }
   const rawUrl = (typeof url === 'string' || url instanceof String) ? url : url.raw


### PR DESCRIPTION
Simply checks that `url` is not undefined first.