### PR TITLE
feat: add default value from description

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,16 +229,30 @@ function parseParameters (query, header, paths, paramsMeta = {}, pathVars) {
   return (parameters.length) ? { parameters } : {}
 }
 
+function extractDefaultValue (description) {
+  const defaultValue = (description || '').match(/\[default=(.*?)(?<!\\)]/i)
+  if (!defaultValue) return {}
+  return {
+    default: JSON.parse(defaultValue[1])
+  }
+}
+
+function extractDescription (description) {
+  const value = (description || '').replace(/ ?(\[required\]|\[default=(.*?)(?<!\\)\]) ?/gi, '').trim()
+  return { description: value }
+}
+
 /* Accumulator function for different types of parameters */
 function mapParameters (type) {
   return (parameters, { key, description, value }) => {
     const required = /\[required\]/gi.test(description)
+
     parameters.push({
       name: key,
       in: type,
-      schema: { type: inferType(value) },
+      schema: { type: inferType(value), ...extractDefaultValue(description) },
       ...(required ? { required } : {}),
-      ...(description ? { description: description.replace(/ ?\[required\] ?/gi, '') } : {}),
+      ...extractDescription(description),
       ...(value ? { example: value } : {})
     })
     return parameters
@@ -254,9 +268,9 @@ function extractPathParameters (path, paramsMeta, pathVars) {
     return {
       name,
       in: 'path',
-      schema: { type },
+      schema: { type, ...extractDefaultValue(description) },
       required: true,
-      ...(description ? { description } : {}),
+      ...extractDescription(description),
       ...(example ? { example } : {})
     }
   })


### PR DESCRIPTION
This PR doesn't contain any tests for default value but I've tried it and seems to work.

https://github.com/joolfe/postman-to-openapi/issues/195

Here is a playground for the regexp `[default=value]`
https://regex101.com/r/oGS42o/1