### PR TITLE
refactor: create folder when writing output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { promises: { writeFile, readFile } } = require('fs')
+const { promises: { writeFile, readFile, mkdir } } = require('fs')
+const { dirname } = require("path")
 const { dump } = require('js-yaml')
 const { parseMdTable } = require('./md-utils')
 const { version } = require('../package.json')
@@ -68,9 +69,16 @@ async function postmanToOpenApi (input, output, {
   }
   const openApiDoc = outputFormat === 'json' ? JSON.stringify(openApi, null, 4) : dump(openApi, { skipInvalid: true })
   if (output != null) {
-    await writeFile(output, openApiDoc, 'utf8')
+    await writeOutput(output, openApiDoc, 'utf8')
   }
   return openApiDoc
+}
+
+/* Write file with the directory */
+async function writeOutput(outputFile, contents, encoding) {
+  mkdir(dirname(outputFile), { recursive: true }).then(
+    async () => await writeFile(outputFile, contents, encoding)
+  )
 }
 
 /* Calculate the tags for folders items based on the options */


### PR DESCRIPTION
This PR fix `[Error: ENOENT: no such file or directory, open 'D:\Projects\postman-to-markdown\api\collection.yml']` when the folder is not exist.