### PR TITLE
Generating Schemas from examples

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const { parseMdTable } = require('./md-utils')
 const { version } = require('../package.json')
 const replacePostmanVariables = require('./var-replacer')
 const jsonc = require('jsonc-parser')
+const GenerateSchema = require("generate-schema");
+const jsonEasyStrip = require('json-easy-strip');
 
 async function postmanToOpenApi (input, output, {
   info = {}, defaultTag = 'default', pathDepth = 0,
@@ -525,8 +527,9 @@ function parseContent (bodiesByLanguage) {
   const content = Object.entries(bodiesByLanguage)
     .reduce((content, [language, bodies]) => {
       if (language === 'json') {
+        parseSchema(bodies)
         content['application/json'] = {
-          schema: { type: 'object' },
+          ...parseSchema(bodies),
           ...parseExamples(bodies, 'json')
         }
       } else {
@@ -538,6 +541,22 @@ function parseContent (bodiesByLanguage) {
       return content
     }, {})
   return { content }
+}
+
+function parseSchema(bodies) {
+  // joining all bodies in an array
+  const jsonBodies = bodies.map(({ body }) => {
+    try {
+      const json = jsonEasyStrip.strip(body)
+      return json
+    } catch(err) {
+      // TODO: currently supressing this error in favour of other JSON validations
+    }
+  })
+
+  // just need the `items` as it was converted into an array just before
+  const schema = GenerateSchema.json(jsonBodies).items
+  return { schema }
 }
 
 function parseExamples (bodies, language) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ const { version } = require('../package.json')
 const replacePostmanVariables = require('./var-replacer')
 const jsonc = require('jsonc-parser')
 const GenerateSchema = require("generate-schema");
-const jsonEasyStrip = require('json-easy-strip');
 
 async function postmanToOpenApi (input, output, {
   info = {}, defaultTag = 'default', pathDepth = 0,
@@ -547,7 +546,7 @@ function parseSchema(bodies) {
   // joining all bodies in an array
   const jsonBodies = bodies.map(({ body }) => {
     try {
-      const json = jsonEasyStrip.strip(body)
+      const json = jsonc.parse(body)
       return json
     } catch(err) {
       // TODO: currently supressing this error in favour of other JSON validations

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0",
+        "generate-schema": "^2.6.0",
         "js-yaml": "^4.1.0",
+        "json-easy-strip": "^1.0.6",
         "jsonc-parser": "3.2.0",
         "marked": "^4.1.0",
         "mustache": "^4.2.0"
@@ -2665,6 +2667,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/generate-schema/-/generate-schema-2.6.0.tgz",
+      "integrity": "sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA==",
+      "dependencies": {
+        "commander": "^2.9.0",
+        "type-of-is": "^3.4.0"
+      },
+      "bin": {
+        "generate-schema": "bin/generate-schema"
+      }
+    },
+    "node_modules/generate-schema/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3519,6 +3538,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/json-easy-strip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json-easy-strip/-/json-easy-strip-1.0.6.tgz",
+      "integrity": "sha512-hof2dl1Fuzl+VV+bC9PsUDcce+cCa4EiTIDvfKgrq2OxHPzT/+rQhGSNvfs+jnDICdgNThw2jO6HZI9wBz9kIg=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -5404,6 +5428,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-of-is": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-of-is/-/type-of-is-3.5.1.tgz",
+      "integrity": "sha512-SOnx8xygcAh8lvDU2exnK2bomASfNjzB3Qz71s2tw9QnX8fkAo7aC+D0H7FV0HjRKj94CKV2Hi71kVkkO6nOxg==",
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -7719,6 +7751,22 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "generate-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/generate-schema/-/generate-schema-2.6.0.tgz",
+      "integrity": "sha512-EUBKfJNzT8f91xUk5X5gKtnbdejZeE065UAJ3BCzE8VEbvwKI9Pm5jaWmqVeK1MYc1g5weAVFDTSJzN7ymtTqA==",
+      "requires": {
+        "commander": "^2.9.0",
+        "type-of-is": "^3.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8318,6 +8366,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-easy-strip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/json-easy-strip/-/json-easy-strip-1.0.6.tgz",
+      "integrity": "sha512-hof2dl1Fuzl+VV+bC9PsUDcce+cCa4EiTIDvfKgrq2OxHPzT/+rQhGSNvfs+jnDICdgNThw2jO6HZI9wBz9kIg=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -9707,6 +9760,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "type-of-is": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/type-of-is/-/type-of-is-3.5.1.tgz",
+      "integrity": "sha512-SOnx8xygcAh8lvDU2exnK2bomASfNjzB3Qz71s2tw9QnX8fkAo7aC+D0H7FV0HjRKj94CKV2Hi71kVkkO6nOxg=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "commander": "^8.3.0",
         "generate-schema": "^2.6.0",
         "js-yaml": "^4.1.0",
-        "json-easy-strip": "^1.0.6",
         "jsonc-parser": "3.2.0",
         "marked": "^4.1.0",
         "mustache": "^4.2.0"
@@ -3538,11 +3537,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/json-easy-strip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/json-easy-strip/-/json-easy-strip-1.0.6.tgz",
-      "integrity": "sha512-hof2dl1Fuzl+VV+bC9PsUDcce+cCa4EiTIDvfKgrq2OxHPzT/+rQhGSNvfs+jnDICdgNThw2jO6HZI9wBz9kIg=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -8366,11 +8360,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
-    },
-    "json-easy-strip": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/json-easy-strip/-/json-easy-strip-1.0.6.tgz",
-      "integrity": "sha512-hof2dl1Fuzl+VV+bC9PsUDcce+cCa4EiTIDvfKgrq2OxHPzT/+rQhGSNvfs+jnDICdgNThw2jO6HZI9wBz9kIg=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "commander": "^8.3.0",
     "generate-schema": "^2.6.0",
     "js-yaml": "^4.1.0",
-    "json-easy-strip": "^1.0.6",
     "jsonc-parser": "3.2.0",
     "marked": "^4.1.0",
     "mustache": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
   },
   "dependencies": {
     "commander": "^8.3.0",
+    "generate-schema": "^2.6.0",
     "js-yaml": "^4.1.0",
+    "json-easy-strip": "^1.0.6",
     "jsonc-parser": "3.2.0",
     "marked": "^4.1.0",
     "mustache": "^4.2.0"

--- a/test/resources/output/JsonComments.yml
+++ b/test/resources/output/JsonComments.yml
@@ -74,6 +74,20 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
+                required:
+                  - id
+                  - createdAt
+                  - name
+                  - avatar
               examples:
                 example-0:
                   summary: Create new User example
@@ -159,6 +173,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '50'
                 createdAt: '2021-06-04T23:41:02.287Z'

--- a/test/resources/output/NullHeader.yml
+++ b/test/resources/output/NullHeader.yml
@@ -43,6 +43,16 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  erreur:
+                    type: 'null'
+                  codeErreur:
+                    type: number
+                  contenu:
+                    type: object
+                    properties:
+                      token:
+                        type: string
               example:
                 erreur: null
                 codeErreur: 0

--- a/test/resources/output/Responses.yml
+++ b/test/resources/output/Responses.yml
@@ -74,6 +74,20 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
+                required:
+                  - id
+                  - createdAt
+                  - name
+                  - avatar
               examples:
                 example-0:
                   summary: Create new User example
@@ -159,6 +173,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '50'
                 createdAt: '2021-06-04T23:41:02.287Z'

--- a/test/resources/output/ResponsesEmpty.yml
+++ b/test/resources/output/ResponsesEmpty.yml
@@ -73,7 +73,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                oneOf:
+                  - properties:
+                      id:
+                        type: string
+                      createdAt:
+                        type: string
+                      name:
+                        type: string
+                      avatar:
+                        type: string
+                    type: object
+                  - type: undefined
+                  - type: undefined
               examples:
                 example-0:
                   summary: Create new User example
@@ -158,6 +170,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '50'
                 createdAt: '2021-06-04T23:41:02.287Z'

--- a/test/resources/output/ResponsesMultiLang.yml
+++ b/test/resources/output/ResponsesMultiLang.yml
@@ -74,6 +74,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '51'
                 createdAt: '2021-06-04T15:50:38.568Z'
@@ -153,6 +162,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '50'
                 createdAt: '2021-06-04T23:41:02.287Z'

--- a/test/resources/output/ResponsesNoHeaders.yml
+++ b/test/resources/output/ResponsesNoHeaders.yml
@@ -29,6 +29,20 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
+                required:
+                  - id
+                  - createdAt
+                  - name
+                  - avatar
               examples:
                 example-0:
                   summary: Create new User example
@@ -65,6 +79,15 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  id:
+                    type: string
+                  createdAt:
+                    type: string
+                  name:
+                    type: string
+                  avatar:
+                    type: string
               example:
                 id: '50'
                 createdAt: '2021-06-04T23:41:02.287Z'


### PR DESCRIPTION
Few notable points:
- All the examples are inspected and then a common schema is generated
- This schema is then automatically injected with the already generated response content.
- Only ```application/json``` responses will have a schema.
- Updated test cases to support response schemas

Referencing important issues:
- #22 
- https://github.com/Kinjalrk2k/postman-to-openapi-json-extended/issues/1