### PR TITLE
fix: missing `code` would result in an `undefined` response status

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -500,6 +500,10 @@ function parseResponseFromExamples (responses, responseHeaders) {
   // Group responses by status code
   const statusCodeMap = responses
     .reduce((statusMap, { name, code, status: description, header, body, _postman_previewlanguage: language }) => {
+      if (code === undefined) {
+        code = 'default'
+      }
+
       if (code in statusMap) {
         if (!(language in statusMap[code].bodies)) {
           statusMap[code].bodies[language] = []

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -53,6 +53,7 @@ const EXPECTED_EMPTY_RESPONSES = readFileSync('./test/resources/output/Responses
 const EXPECTED_RESPONSES_MULTI_LANG = readFileSync('./test/resources/output/ResponsesMultiLang.yml', 'utf8')
 const EXPECTED_AUTH_REQUEST = readFileSync('./test/resources/output/AuthRequest.yml', 'utf8')
 const EXPECTED_RESPONSES_NO_HEADERS = readFileSync('./test/resources/output/ResponsesNoHeaders.yml', 'utf8')
+const EXPECTED_RESPONSES_WITHOUT_STATUS_CODE = readFileSync('./test/resources/output/ResponsesWithoutHTTPStatusCode.yml', 'utf8')
 const EXPECTED_FORM_DATA = readFileSync('./test/resources/output/FormData.yml', 'utf8')
 const EXPECTED_FORM_URLENCODED = readFileSync('./test/resources/output/FormUrlencoded.yml', 'utf8')
 const EXPECTED_VARIABLES = readFileSync('./test/resources/output/Variables.yml', 'utf8')
@@ -134,6 +135,7 @@ describe('Library specs', function () {
       const COLLECTION_JSON_COMMENTS = `./test/resources/input/${version}/JsonComments.json`
       const COLLECTION_DISABLED = `./test/resources/input/${version}/DisabledParams.json`
       const COLLECTION_OPERATION_IDS = `./test/resources/input/${version}/OperationIds.json`
+      const COLLECTION_RESPONSES_WITHOUT_STATUS_CODE = `./test/resources/input/${version}/ResponsesWithoutHTTPStatusCode.json`
 
       it('should work with a basic transform', async function () {
         const result = await postmanToOpenApi(COLLECTION_BASIC, OUTPUT_PATH, {})
@@ -416,6 +418,11 @@ describe('Library specs', function () {
       it('should add responses from multiple format for the same status code (text and json)', async function () {
         const result = await postmanToOpenApi(COLLECTION_RESPONSES_MULTI_LANG, OUTPUT_PATH, { pathDepth: 2 })
         equal(result, EXPECTED_RESPONSES_MULTI_LANG)
+      })
+
+      it('should add responses from postman examples even if they are missing an HTTP Status Code', async function () {
+        const result = await postmanToOpenApi(COLLECTION_RESPONSES_WITHOUT_STATUS_CODE, OUTPUT_PATH, { pathDepth: 2 })
+        equal(result, EXPECTED_RESPONSES_WITHOUT_STATUS_CODE)
       })
 
       it('should work if auth only defined at request level', async function () {

--- a/test/resources/input/v2/ResponsesWithoutHTTPStatusCode.json
+++ b/test/resources/input/v2/ResponsesWithoutHTTPStatusCode.json
@@ -1,0 +1,126 @@
+{
+	"info": {
+		"_postman_id": "7f7ad829-6db0-4229-9c38-5e9f341ec7bb",
+		"name": "Responses",
+		"description": "Postman collection with saved responses that don't have an HTTP Status Code",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Create new User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"100\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n  }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+				"description": "Create a new user into your amazing API"
+			},
+			"response": [
+				{
+					"name": "Create new User example",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"100\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n  }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users"
+					},
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:42:32 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"51\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "version",
+			"value": "1.2.0"
+		},
+		{
+			"key": "user_id",
+			"value": "50"
+		}
+	]
+}

--- a/test/resources/input/v21/ResponsesWithoutHTTPStatusCode.json
+++ b/test/resources/input/v21/ResponsesWithoutHTTPStatusCode.json
@@ -1,0 +1,152 @@
+{
+	"info": {
+		"_postman_id": "7f7ad829-6db0-4229-9c38-5e9f341ec7bb",
+		"name": "Responses",
+		"description": "Postman collection with saved responses that don't have an HTTP Status Code",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Create new User",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"100\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n  }",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+					"protocol": "https",
+					"host": [
+						"60bb37ab42e1d000176206c3",
+						"mockapi",
+						"io"
+					],
+					"path": [
+						"api",
+						"v1",
+						"users"
+					]
+				},
+				"description": "Create a new user into your amazing API"
+			},
+			"response": [
+				{
+					"name": "Create new User example",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"100\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n  }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://60bb37ab42e1d000176206c3.mockapi.io/api/v1/users",
+							"protocol": "https",
+							"host": [
+								"60bb37ab42e1d000176206c3",
+								"mockapi",
+								"io"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "X-Powered-By",
+							"value": "Express"
+						},
+						{
+							"key": "Access-Control-Allow-Origin",
+							"value": "*"
+						},
+						{
+							"key": "Access-Control-Allow-Methods",
+							"value": "GET,PUT,POST,DELETE,OPTIONS"
+						},
+						{
+							"key": "Access-Control-Allow-Headers",
+							"value": "X-Requested-With,Content-Type,Cache-Control,access_token"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Content-Length",
+							"value": "131"
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "Date",
+							"value": "Sat, 05 Jun 2021 08:42:32 GMT"
+						},
+						{
+							"key": "Via",
+							"value": "1.1 vegur"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": \"51\",\n    \"createdAt\": \"2021-06-04T15:50:38.568Z\",\n    \"name\": \"Carol\",\n    \"avatar\": \"https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg\"\n}"
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "version",
+			"value": "1.2.0"
+		},
+		{
+			"key": "user_id",
+			"value": "50"
+		}
+	]
+}

--- a/test/resources/output/ResponsesWithoutHTTPStatusCode.yml
+++ b/test/resources/output/ResponsesWithoutHTTPStatusCode.yml
@@ -1,0 +1,80 @@
+openapi: 3.0.0
+info:
+  title: Responses
+  description: Postman collection with saved responses that don't have an HTTP Status Code
+  version: 1.2.0
+servers:
+  - url: https://60bb37ab42e1d000176206c3.mockapi.io
+paths:
+  /users:
+    post:
+      tags:
+        - default
+      summary: Create new User
+      description: Create a new user into your amazing API
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                id: '100'
+                createdAt: '2021-06-04T15:50:38.568Z'
+                name: Carol
+                avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg
+      responses:
+        default:
+          headers:
+            Server:
+              schema:
+                type: string
+                example: Cowboy
+            Connection:
+              schema:
+                type: string
+                example: keep-alive
+            X-Powered-By:
+              schema:
+                type: string
+                example: Express
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                example: '*'
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+                example: GET,PUT,POST,DELETE,OPTIONS
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+                example: X-Requested-With,Content-Type,Cache-Control,access_token
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            Content-Length:
+              schema:
+                type: integer
+                example: '131'
+            Vary:
+              schema:
+                type: string
+                example: Accept-Encoding
+            Date:
+              schema:
+                type: string
+                example: Sat, 05 Jun 2021 08:42:32 GMT
+            Via:
+              schema:
+                type: string
+                example: 1.1 vegur
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                id: '51'
+                createdAt: '2021-06-04T15:50:38.568Z'
+                name: Carol
+                avatar: https://cdn.fakercloud.com/avatars/nelsonjoyce_128.jpg


### PR DESCRIPTION
If `code` is missing in a Postman-documented response example then an OpenAPI definition `response` entry will be generated with an invalid HTTP Status code of `undefined`. As `code` isn't required by the Postman spec[^1] I'm opting to default to an OAS-compliant status code of `default` rather than 200 (or something else).

[^1]: There's no `required` declaration for `code` anywhere in the [v2.1](https://schema.postman.com/json/collection/v2.1.0/collection.json) or [v2.0](https://schema.postman.com/json/collection/v2.0.0/collection.json) schemas.